### PR TITLE
プレイヤー詳細ページの追加とページ遷移の実装

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.7.6")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/akitsulab/soccersimulation/MainActivity.kt
+++ b/app/src/main/java/com/akitsulab/soccersimulation/MainActivity.kt
@@ -14,12 +14,18 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.akitsulab.soccersimulation.ui.theme.SoccersimulationTheme
 
 class MainActivity : ComponentActivity() {
@@ -32,29 +38,86 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    MainContent()
+                    val navController = rememberNavController()
+                    NavHost(navController = navController, startDestination = SoccerScreen.PlayerList.name) {
+                        composable(route = SoccerScreen.PlayerList.name) {
+                            PlayerListScreen(onClickButton = { name, position ->
+                                navController.navigate("${SoccerScreen.PlayerDetailedInfo.name}/$name/$position")})
+                        }
+                        composable(
+                            route = "${SoccerScreen.PlayerDetailedInfo.name}/{name}/{position}",
+                            arguments = listOf(
+                                navArgument("name") { type = NavType.StringType },
+                                navArgument("position") { type = NavType.StringType }
+                            )
+                        ){ backStackEntry ->
+                            val name = backStackEntry.arguments?.getString("name") ?: ""
+                            val position = backStackEntry.arguments?.getString("position") ?: ""
+                            PlayerDetailedInfoScreen(name = name, position = position, onClickButton = {navController.navigateUp()})
+                        }
+                    }
                 }
             }
         }
     }
 }
 
+enum class SoccerScreen(){
+    PlayerList,
+    PlayerDetailedInfo
+}
+
 @Composable
-fun MainContent(modifier: Modifier = Modifier) {
+fun PlayerDetailedInfoScreen(name: String, position: String, onClickButton: () -> Unit, modifier: Modifier = Modifier){
     Column(
         horizontalAlignment = Alignment.Start,
         modifier = Modifier
             .padding(10.dp)
             .verticalScroll(rememberScrollState())
     ) {
-        PlayerOverView(name = "織田 信長", position = "FW")
-        PlayerOverView(name = "豊臣 秀吉", position = "FW")
-        PlayerOverView(name = "徳川 家康", position = "FW")
-        PlayerOverView(name = "前田 利家", position = "FW")
-        PlayerOverView(name = "香川 真司", position = "MF")
-        PlayerOverView(name = "本田 圭佑", position = "MF")
-        PlayerOverView(name = "岡崎 慎二", position = "FW")
-        PlayerOverView(name = "長友 佑都", position = "DF")
+        Column {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.icon_user),
+                    contentDescription = "ユーザーアイコン",
+                    modifier = Modifier
+                        .size(100.dp)
+                )
+                Column {
+                    Text(
+                        text = name,
+                    )
+                    Text(
+                        text = "ポジション: $position",
+                    )
+                }
+            }
+            TextButton(onClick = onClickButton) {
+                Text(text = "戻る")
+            }
+        }
+
+    }
+}
+
+@Composable
+fun PlayerListScreen(onClickButton: (String, String) -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = Modifier
+            .padding(10.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        PlayerOverView(name = "織田 信長", position = "FW", onClickButton = {onClickButton("織田 信長", "FW")})
+        PlayerOverView(name = "豊臣 秀吉", position = "FW", onClickButton = {onClickButton("豊臣 秀吉", "FW")})
+        PlayerOverView(name = "徳川 家康", position = "FW", onClickButton = {onClickButton("徳川 家康", "FW")})
+        PlayerOverView(name = "前田 利家", position = "FW", onClickButton = {onClickButton("前田 利家", "FW")})
+        PlayerOverView(name = "香川 真司", position = "MF", onClickButton = {onClickButton("香川 真司", "MF")})
+        PlayerOverView(name = "本田 圭佑", position = "MF", onClickButton = {onClickButton("本田 圭佑", "MF")})
+        PlayerOverView(name = "岡崎 慎二", position = "FW", onClickButton = {onClickButton("岡崎 慎二", "FW")})
+        PlayerOverView(name = "長友 佑都", position = "DF", onClickButton = {onClickButton("長友 佑都", "DF")})
     }
 }
 
@@ -62,6 +125,7 @@ fun MainContent(modifier: Modifier = Modifier) {
 fun PlayerOverView(
     name: String,
     position: String,
+    onClickButton: () -> Unit
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically
@@ -73,9 +137,11 @@ fun PlayerOverView(
                 .size(100.dp)
         )
         Column {
-            Text(
-                text = name,
-            )
+            TextButton(onClick = onClickButton) {
+                Text(
+                    text = name,
+                )
+            }
             Text(
                 text = "ポジション: $position",
             )
@@ -86,8 +152,16 @@ fun PlayerOverView(
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun PlayerListPreview() {
     SoccersimulationTheme {
-        MainContent()
+        PlayerListScreen(onClickButton = {_,_ ->})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PlayerInfoPreview() {
+    SoccersimulationTheme {
+        PlayerDetailedInfoScreen(name = "長岡 慶太", position = "CEO", onClickButton = {})
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.0" apply false
+    id("com.android.application") version "8.2.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }


### PR DESCRIPTION
Issue: https://github.com/Akitsu-Lab/soccersimulation/issues/2

- プレイヤー詳細ページを追加
- ページ遷移の実装

https://github.com/Akitsu-Lab/soccersimulation/assets/51395204/8aa38677-b729-4b69-ae66-ef76c01324cf

